### PR TITLE
fix: Allow to be used with hot-reloading

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ PwaManifestWebpackPlugin.prototype.createManifest= function(compilation) {
 
 PwaManifestWebpackPlugin.prototype.genIcons = function(compiler, compilation, callback) {
   var self = this;
-  var sizes = this.options.icon.sizes;
+  var sizes = this.options.icon.sizes.slice();
   var src = this.options.icon.src;
   var outputPath = compiler.options.output.path;
 
@@ -87,7 +87,9 @@ PwaManifestWebpackPlugin.prototype.genIcons = function(compiler, compilation, ca
     });
   }
 
-  if (src && Array.isArray(sizes)) {
+  if (src && Array.isArray(sizes) && !!sizes.length) {
+    this.options.icons = [];
+
     lwip.open(src, function(err, image) {
       resize(image, sizes);
     });


### PR DESCRIPTION
I've been trying to run this in a setup with hot reloading and I've ran into some issues.

The fixes I propose do the following:
 - Do not mutate the options Webpack passes as arguments. Previously, after first invocation of `getIcons` the `sizes` array would be empty, crashing the plugin when invoked the second time.
 - Guard against empty `sizes` - no longer crashes if passed an empty array (maybe a warning would be nice?).
 - Clear the `icons` array before populating it. Otherwise it keeps duplicating icons when called more then one time.